### PR TITLE
Installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,7 @@ $ sudo agda-mode compile
 ```
 
 ### Debian and Ubuntu
+
 Start by installing `emacs`, `git`, `ghc`, `cabal-install`, `alex` and
 `happy` using the package manager:
 ```bash
@@ -34,7 +35,22 @@ your home directory:
 $ mkdir ~/mgs-2019
 ```
 
-#### Installing Agda 2.6.0 
+#### Standard Agda installation
+This section describes the standard way to install Agda 2.6.0.
+If this does not work, then please try the instruction using Git.
+```bash
+$ cd ~/mgs-2019
+$ mkdir agda
+$ cd agda
+$ cabal sandbox init
+$ cabal update
+$ cabal install Agda
+```
+
+Now continue with [Setting up Emacs to work with
+Agda](#Setting-up-Emacs-to-work-with-Agda).
+
+#### Agda installation using Git
 Inside that directory, we download and install Agda 2.6.0:
 ```bash
 $ cd ~/mgs-2019
@@ -45,6 +61,7 @@ $ cabal sandbox init
 $ cabal update
 $ cabal install
 ```
+
 #### Setting up Emacs to work with Agda
 Finally, we set up Emacs to work with Agda:
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sources and scripts to generate the lecture notes available at
 https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html
 
-Agda [2.6.0](https://agda.readthedocs.io/en/v2.6.0/getting-started/installation.html) is required.
+Agda [2.6.0](https://agda.readthedocs.io/en/v2.6.0/getting-started/installation.html) is required. Consult the [installation instructions](INSTALL.md) to help you set up Agda and Emacs for the Midlands Graduate School.
 
 * The (literate) `*.lagda` files are used to generate the `html` pages with the script `../build`.
 


### PR DESCRIPTION
As Agda just released 2.6.0, you can now run `cabal install Agda`.

Our installation instructions are more comprehensive (in some way) than Agda's documentation, so we should refer to them in README.md.