### PR TITLE
improve emacs config and add jekyll install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,10 +85,6 @@ $ cd ~/mgs-2019
 $ ./mgs-emacs
 ```
 
-#### Generating html and agda
-
-See the file INSTALL_Jekyll.md.
-
 ## MacOS
 We will use the [Nix Package Manager](https://nixos.org/nix/).
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,11 +56,13 @@ Inside that directory, we download and install Agda 2.6.0:
 $ cd ~/mgs-2019
 $ git clone https://github.com/agda/agda
 $ cd agda
-$ git checkout release-2.6.0
+$ git checkout release-2.6.0  # (cf. Hint below)
 $ cabal sandbox init
 $ cabal update
 $ cabal install
 ```
+
+*Hint*. These notes depend on release 2.6.0, but just in case you want to see what other Agda releases are available, type the *parital* command `git checkout release-` and hit the `Tab` key a few times.
 
 #### Setting up Emacs to work with Agda
 Finally, we set up Emacs to work with Agda:
@@ -74,7 +76,7 @@ $ cp ~/.emacs ~/mgs-2019/
 $ cp ~/.emacs.backup ~/.emacs
 $ cd ~/mgs-2019
 $ echo '#!/bin/bash' > mgs-emacs
-$ echo 'PATH=~/mgs-2019/agda/.cabal-sandbox/bin/:$PATH emacs --no-init-file --load ~/mgs-2019/.emacs' >> mgs-emacs
+$ echo 'PATH=~/mgs-2019/agda/.cabal-sandbox/bin/:$PATH emacs --no-init-file --load ~/mgs-2019/.emacs \$@' >> mgs-emacs
 $ chmod +x mgs-emacs
 ```
 Now to get Emacs with Agda mode, start Emacs using:
@@ -82,6 +84,10 @@ Now to get Emacs with Agda mode, start Emacs using:
 $ cd ~/mgs-2019
 $ ./mgs-emacs
 ```
+
+#### Generating html and agda
+
+See the file INSTALL_Jekyll.md.
 
 ## MacOS
 We will use the [Nix Package Manager](https://nixos.org/nix/).

--- a/JEKYLL.md
+++ b/JEKYLL.md
@@ -1,0 +1,24 @@
+
+## Installing Jekyll on Ubuntu 18.04
+
+If you want to generate html pages from the notes and serve them up in your browser, you will need jekyll.
+
+Here are steps you can follow on Ubuntu 18.04 to install the latest version.
+
+```bash
+sudo apt update
+sudo apt -y upgrade
+sudo reboot
+sudo apt -y install make build-essential
+sudo apt -y install ruby ruby-dev
+export GEM_HOME=$HOME/gems
+export PATH=$HOME/gems/bin:$PATH
+
+source ~/.bashrc
+
+gem install bundler
+gem install jekyll
+```
+
+(Reference: https://computingforgeeks.com/how-to-install-jekyll-on-ubuntu-18-04/)
+


### PR DESCRIPTION
[I have other suggestions (about the actual content of the notes), but I'll start with this small pull request and see how it goes...]

adding \$@ enables users to load files when launching the new emacs config; e.g., `mgs-emacs *.agda *.lagda` will now start emacs with all .agda and .lagda files in the current directory open.

As for adding instructions for installing a recent version of Jekyll (instead of the very old version that is installed by default with apt), I was hoping this would allow me to generate updated html and agda files, but it doesn't seem to work.  I suspect there are parts missing from the master repository that are required for this.

Here are the errors I get when I run `./build`:

```
williamdemeo@lampe:~/git/hub/AGDA/HoTT/HoTT-UF-Agda-Lecture-Notes$ ./build
/home/williamdemeo/git/hub/AGDA/HoTT/HoTT-UF-Agda-Lecture-Notes/HoTT-UF-Agda.lagda:1309,24-24
/home/williamdemeo/git/hub/AGDA/HoTT/HoTT-UF-Agda-Lecture-Notes/HoTT-UF-Agda.lagda:1309,24: expected sequence of possibly hidden bound identifiers
:<ERROR>
 Σ Y) → A (x , y)

Σ-induction...
cp: cannot stat 'html/HoTT-UF-Agda.tex': No such file or directory
mv: cannot stat 'html/HoTT-UF-Agda.tex': No such file or directory
mv: cannot stat 'html/Universes.tex': No such file or directory

Warning: HTML is currently generated for ALL files which can be
reached from the given module, including library files.

Generating HTML for Agda.Primitive (html/Agda.Primitive.html).
Generating HTML for Agda.Primitive.Cubical (html/Agda.Primitive.Cubical.html).
Generating HTML for Universes (html/Universes.html).
Traceback (most recent call last):
	15: from /home/williamdemeo/gems/bin/jekyll:23:in `<main>'
	14: from /home/williamdemeo/gems/bin/jekyll:23:in `load'
	13: from /home/williamdemeo/gems/gems/jekyll-4.0.0/exe/jekyll:11:in `<top (required)>'
	12: from /home/williamdemeo/gems/gems/jekyll-4.0.0/lib/jekyll/plugin_manager.rb:52:in `require_from_bundler'
	11: from /usr/lib/ruby/vendor_ruby/bundler.rb:107:in `setup'
	10: from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:20:in `setup'
	 9: from /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:108:in `block in definition_method'
	 8: from /usr/lib/ruby/vendor_ruby/bundler/definition.rb:226:in `requested_specs'
	 7: from /usr/lib/ruby/vendor_ruby/bundler/definition.rb:237:in `specs_for'
	 6: from /usr/lib/ruby/vendor_ruby/bundler/definition.rb:170:in `specs'
	 5: from /usr/lib/ruby/vendor_ruby/bundler/definition.rb:257:in `resolve'
	 4: from /usr/lib/ruby/vendor_ruby/bundler/resolver.rb:22:in `resolve'
	 3: from /usr/lib/ruby/vendor_ruby/bundler/resolver.rb:48:in `start'
	 2: from /usr/lib/ruby/vendor_ruby/bundler/resolver.rb:257:in `verify_gemfile_dependencies_are_found!'
	 1: from /usr/lib/ruby/vendor_ruby/bundler/resolver.rb:257:in `each'
/usr/lib/ruby/vendor_ruby/bundler/resolver.rb:289:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'jekyll (~> 3.8)' in any of the gem sources listed in your Gemfile. (Bundler::GemNotFound)
cp: cannot stat '_site/index.html': No such file or directory
cp: cannot stat '_site/HoTT-UF-Agda.html': No such file or directory
cp: cannot stat '_site/Universes.html': No such file or directory
cp: cannot stat '_site/Agda.Primitive.html': No such file or directory
cp: cannot stat '_site/css': No such file or directory
cp: cannot stat '_site/LICENSE': No such file or directory
Now will generate pdf from HTML
[0321/165424.522453:ERROR:command_buffer_proxy_impl.cc(125)] ContextResult::kTransientFailure: Failed to send GpuChannelMsg_CreateCommandBuffer.
[0321/165424.554905:INFO:headless_shell.cc(619)] Written to file pdf/all/HoTT-UF-Agda.pdf.

```
