### PR TITLE
remove unused variable a in transportd

### DIFF
--- a/HoTT-UF-Agda.lagda
+++ b/HoTT-UF-Agda.lagda
@@ -3302,19 +3302,19 @@ transport-× A B (refl _) = refl _
 
 
 transportd : {X : 𝓤 ̇ } (A : X → 𝓥 ̇ ) (B : (x : X) → A x → 𝓦 ̇ )
-             {x : X} (a : A x) ((a' , b) : Σ a ꞉ A x , B x a) {y : X} (p : x ≡ y)
+             {x : X} ((a' , b) : Σ a ꞉ A x , B x a) {y : X} (p : x ≡ y)
            → B x a' → B y (transport A p a')
 
-transportd A B a σ (refl y) = id
+transportd A B σ (refl y) = id
 
 
 transport-Σ : {X : 𝓤 ̇ } (A : X → 𝓥 ̇ ) (B : (x : X) → A x → 𝓦 ̇ )
-              {x : X} (y : X) (p : x ≡ y) (a : A x) {(a' , b) : Σ a ꞉ A x , B x a}
+              {x : X} (y : X) (p : x ≡ y) {(a' , b) : Σ a ꞉ A x , B x a}
 
             → transport (λ x → Σ y ꞉ A x , B x y) p (a' , b)
-            ≡ transport A p a' , transportd A B a (a' , b) p b
+            ≡ transport A p a' , transportd A B (a' , b) p b
 
-transport-Σ A B {x} x (refl x) a {σ} = refl σ
+transport-Σ A B {x} x (refl x) {σ} = refl σ
 \end{code}
 
 [<sub>Table of contents ⇑</sub>](HoTT-UF-Agda.html#contents)


### PR DESCRIPTION
Hi Martin,

I have been working through your notes and having great fun with it.

I noticed that in the definition of transportd there is an unused premise (a : A x).

Best regards,
Tashi